### PR TITLE
bower.json improvements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,18 @@
 {
   "name": "oraclejet",
   "description": "Oracle JET distribution",
-  "version": "2.0.0",
   "authors": [
     "Oracle"
   ],
-  "license": "UPL",
+  "license": "UPL-1.0",
   "homepage": "http://oraclejet.org",
-  "moduleType": [],
+  "moduleType": "amd",
   "ignore":["samples"],
   "main":[],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/oracle/oraclejet.git"
+  },
   "dependencies": 
   {
     "es6-promise": "1.0.0",


### PR DESCRIPTION
`version` is deprecated according to bower specs. `license` should use SPDX identifier. `moduleType` and `repository` weren't specified. For more info see https://github.com/bower/spec/blob/master/json.md

Please see this a first step of the community trying to improve Oracle JET. Please consider moving your own development efforts to github instead of periodic source drops and accept issues and pull requests.
