### PR TITLE
update webpack dependency mapping

### DIFF
--- a/dist/webpack-tools/webpack.config.js
+++ b/dist/webpack-tools/webpack.config.js
@@ -27,18 +27,19 @@ module.exports = {
   resolve: {
     alias: {
       // path mappings go here
-      'knockout': path.resolve(__dirname, './web/js/libs/knockout/knockout-3.4.2.debug'),
-      'jquery': path.resolve(__dirname, './web/js/libs/jquery/jquery-3.3.1'),
+      'knockout': path.resolve(__dirname, './web/js/libs/knockout/knockout-3.5.0.debug'),
+      'jquery': path.resolve(__dirname, './web/js/libs/jquery/jquery-3.4.1'),
       'jqueryui-amd': path.resolve(__dirname, './web/js/libs/jquery/jqueryui-amd-1.12.1'),
       'promise': path.resolve(__dirname, './web/js/libs/es6-promise/es6-promise'),
       'hammerjs': path.resolve(__dirname, './web/js/libs/hammer/hammer-2.0.8'),
-      'ojdnd': path.resolve(__dirname, './web/js/libs/dnd-polyfill/dnd-polyfill-1.0.0'),
-      'ojs': path.resolve(__dirname, './web/js/libs/oj/v6.0.0/debug'),
-      'ojtranslations': path.resolve(__dirname, './web/js/libs/oj/v6.0.0/resources'),
+      'ojdnd': path.resolve(__dirname, './web/js/libs/dnd-polyfill/dnd-polyfill-1.0.1'),
+      'ojs': path.resolve(__dirname, './web/js/libs/oj/v8.0.0/debug'),
+      'ojtranslations': path.resolve(__dirname, './web/js/libs/oj/v8.0.0/resources'),
       'signals': path.resolve(__dirname, './web/js/libs/js-signals/signals'),
       'touchr': path.resolve(__dirname, './web/js/libs/touchr/touchr'),
       'customElements': path.resolve(__dirname, './web/js/libs/webcomponents/custom-elements.min'),
-      'appController': path.resolve(__dirname, './web/js/appController')
+      'appController': path.resolve(__dirname, './web/js/appController'),
+      'accUtils': path.resolve(__dirname, './web/js/accUtils')
     }
   },
   plugins: [
@@ -74,7 +75,7 @@ module.exports = {
           }
         },
         // Point this setting to the root folder for the associated JET distribution (could be a CDN). Used by the oj.Config.getResourceUri() call
-        baseResourceUrl: "./web/js/libs/oj/v6.0.0"
+        baseResourceUrl: "./web/js/libs/oj/v8.0.0"
       }
     )
 


### PR DESCRIPTION
I was following the directions specified [here](https://github.com/oracle/oraclejet/blob/master/dist/webpack-tools/readme.txt#L24) to get Webpack working, but the provided `dist/webpack-tools/webpack.config.js` file was out-of-date with this example codebase.